### PR TITLE
Fix MaxLength for non-ASCII characters

### DIFF
--- a/filenamify.go
+++ b/filenamify.go
@@ -67,7 +67,7 @@ func FilenamifyV2(str string, optFuns ...func(options *Options)) (string, error)
 	} else {
 		limitLength = MAX_FILENAME_LENGTH
 	}
-	strBuf := []byte(str)
+	strBuf := []rune(str)
 	strBuf = strBuf[0:int(math.Min(float64(limitLength), float64(len(strBuf))))]
 
 	return string(strBuf), nil

--- a/filenamify_test.go
+++ b/filenamify_test.go
@@ -136,4 +136,13 @@ func TestFilenamifyLength(t *testing.T) {
 		t.Error("TestFilenamifyLength error")
 	}
 
+	// test max length with non-ASCII characters
+	expect := "你好"
+	input := "你好，世界！"
+	output, _ := FilenamifyV2(input, func(options *Options) { options.MaxLength = 2 })
+	if output != expect {
+		t.Errorf("expect:'%v' got:'%v'", expect, output)
+	} else {
+		t.Log("pass")
+	}
 }


### PR DESCRIPTION
Fix #5 

Non-ASCII characters consist of more than one byte. Using the length of byte to truncate may produce special characters, which need to be replaced by rune.